### PR TITLE
Fixes #2

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { MaterialModule } from './material.module';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { DatetimePipe } from './pipes/datetime.pipe';
 import { DurationPipe } from './pipes/duration.pipe';
+import { DisplayTimeLeftPipe } from './pipes/display-time-left.pipe';
 
 @NgModule({
   declarations: [
@@ -18,7 +19,8 @@ import { DurationPipe } from './pipes/duration.pipe';
     TimersComponent,
     TimerComponent,
     DatetimePipe,
-    DurationPipe
+    DurationPipe,
+    DisplayTimeLeftPipe
   ],
   imports: [
     FlexLayoutModule,

--- a/src/app/pipes/display-time-left.pipe.spec.ts
+++ b/src/app/pipes/display-time-left.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { DisplayTimeLeftPipe } from './display-time-left.pipe';
+
+describe('DisplayTimeLeftPipe', () => {
+  it('create an instance', () => {
+    const pipe = new DisplayTimeLeftPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/display-time-left.pipe.ts
+++ b/src/app/pipes/display-time-left.pipe.ts
@@ -1,0 +1,45 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'displayTimeLeft'
+})
+export class DisplayTimeLeftPipe implements PipeTransform {
+  pad(timeUnit: number) { 
+    return timeUnit < 10 ? '0' + timeUnit : timeUnit; 
+  };
+
+
+  convertToDaysHoursMinutesFormat(milliseconds: number): string {
+    const daysInMs = 24 * 60 * 60 * 1000,
+        hoursInMs = 60 * 60 * 1000
+    let days = Math.floor(milliseconds / daysInMs),
+        hours = Math.floor( (milliseconds - days * daysInMs) / hoursInMs),
+        minutes = Math.floor( (milliseconds - days * daysInMs - hours * hoursInMs) / 60000)
+    if( minutes === 60 ){
+      hours++;
+      minutes = 0;
+    }
+    if( hours === 24 ){
+      days++;
+      hours = 0;
+    }
+    return `${days}d ${this.pad(hours)}h  ${this.pad(minutes)}m`
+  }
+
+  convertToMinutesSecondsFormat(milliseconds: number): string {
+    const minutesInMs = 60 * 1000
+    let minutes = Math.floor( (milliseconds) / 60000),
+        seconds = Math.floor( (milliseconds - minutes * minutesInMs) / 1000)
+    return `${this.pad(minutes)}m ${this.pad(seconds)}s`;
+  }
+
+  transform(value: number, ...args: unknown[]): unknown {
+    if(value >= (60 * 60 * 1000 - 999)){
+      return this.convertToDaysHoursMinutesFormat(value);
+    } else if (value > 0) {
+      return this.convertToMinutesSecondsFormat(value)
+    } else {
+      return '00m 00s'
+    }
+  }
+}

--- a/src/app/timers/timer/timer.component.html
+++ b/src/app/timers/timer/timer.component.html
@@ -2,7 +2,7 @@
   <div fxLayout="row" fxLayoutAlign="start" class="header">
     <div fxFlex="100%" fxLayout="column" fxLayoutAlign="start stretch">
       <mat-card-title>{{timer.endDate | datetime}}</mat-card-title>
-      <mat-card-subtitle>{{timerDuration$ | async}}</mat-card-subtitle>
+      <mat-card-subtitle>{{(timerDuration$ | async) | displayTimeLeft }}</mat-card-subtitle>
     </div>
     <div fxLayoutAlign="end" class="actions">
       <!-- <button mat-icon-button><mat-icon>menu</mat-icon></button> -->


### PR DESCRIPTION
Fixes #2 

Creates a custom pipe display-time-left.pipe.ts which can be used on a millisecond number to convert to:

- Day Hour Minute format (Xd XXh XXm) when hours > 0
- Minute Second format (XXm XXs) when seconds > 0
- '00m 00s' when seconds < 0